### PR TITLE
removed test suite from main code

### DIFF
--- a/src/BijectiveHilbert.jl
+++ b/src/BijectiveHilbert.jl
@@ -49,6 +49,4 @@ export Simple2D
 
 include("facecontinuous.jl")
 export FaceContinuous
-
-include("suite.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using BijectiveHilbert
 using SafeTestsets
 using Test
 
+include("suite.jl")
+
 @testset "BijectiveHilbert.jl" begin
 include("test_bitops.jl")
 include("test_gray_code.jl")

--- a/test/suite.jl
+++ b/test/suite.jl
@@ -1,3 +1,8 @@
+module HilbertTestSuite
+using BijectiveHilbert: HilbertAlgorithm, decode_hilbert_zero!, encode_hilbert_zero
+using BijectiveHilbert: index_type, axis_type
+
+
 function check_own_inverse(gg::HilbertAlgorithm, b::Int, n)
     success = true
     p = zeros(axis_type(gg), n)
@@ -80,4 +85,6 @@ for ihidx in 0:(1<<(dim_cnt*m) - 2)  # compare with next, so stop one early.
     end
 end
 success
+end
+
 end

--- a/test/test_facecontinuous.jl
+++ b/test/test_facecontinuous.jl
@@ -50,7 +50,8 @@ end
 
 
 @safetestset facecontinuous_own_inverse = "FaceContinuous is its own inverse" begin
-using BijectiveHilbert: FaceContinuous, check_own_inverse
+using BijectiveHilbert: FaceContinuous
+using ..HilbertTestSuite: check_own_inverse
 for n in [2, 3, 5]
     for b in [2, 3]
         fc = FaceContinuous(b, n)
@@ -61,7 +62,8 @@ end
 
 
 @safetestset facecontinuous_complete_set = "FaceContinuous is complete set" begin
-using BijectiveHilbert: FaceContinuous, check_complete_set
+using BijectiveHilbert: FaceContinuous
+using ..HilbertTestSuite: check_complete_set
 for n in [2, 3, 5]
     for b in [2, 3]
         fc = FaceContinuous(b, n)

--- a/test/test_global_gray.jl
+++ b/test/test_global_gray.jl
@@ -81,7 +81,8 @@ end
 
 
 @safetestset hilbert_one_diff = "GlobalGray values next to each other" begin
-using BijectiveHilbert: GlobalGray, check_complete_set
+using BijectiveHilbert: GlobalGray
+using ..HilbertTestSuite: check_complete_set
 n = 3
 b = 4
 gg = GlobalGray(b, n)

--- a/test/test_hamilton.jl
+++ b/test/test_hamilton.jl
@@ -314,7 +314,8 @@ end
 
 
 @safetestset hilbert_index_complete4d = "hilbert index is a complete set for 4d" begin
-using BijectiveHilbert: SpaceGray, check_complete_set
+using BijectiveHilbert: SpaceGray
+using ..HilbertTestSuite: check_complete_set
 b = 3
 n = 4
 gg = SpaceGray(b, n)
@@ -377,7 +378,8 @@ end
 
 
 @safetestset paper_inv = "paper hilbert is own inverse" begin
-using BijectiveHilbert: check_own_inverse, SpaceGray
+using BijectiveHilbert: SpaceGray
+using ..HilbertTestSuite: check_own_inverse
 for n in 2:5
     for b in 2:4
         gg = SpaceGray(b, n)
@@ -430,7 +432,8 @@ end
 
 
 @safetestset compact_index_is_its_inverse = "compact index is its inverse" begin
-using BijectiveHilbert: Compact, check_own_inverse
+using BijectiveHilbert: Compact
+using ..HilbertTestSuite: check_own_inverse
 using Random
 rng = MersenneTwister(432479874)
 for n = [5]

--- a/test/test_simple2d.jl
+++ b/test/test_simple2d.jl
@@ -22,7 +22,8 @@ end
 
 
 @safetestset simple2d_own_inverse = "simple2d is its own inverse" begin
-  using BijectiveHilbert: Simple2D, check_own_inverse
+  using BijectiveHilbert: Simple2D
+  using ..HilbertTestSuite: check_own_inverse
   gg = Simple2D(Int)
   for b in 2:7
     @test check_own_inverse(gg, b, 2)
@@ -31,7 +32,8 @@ end
 
 
 @safetestset simple2d_complete_set = "simple2d is a complete set" begin
-  using BijectiveHilbert: Simple2D, check_complete_set
+  using BijectiveHilbert: Simple2D
+  using ..HilbertTestSuite: check_complete_set
   gg = Simple2D(Int)
   for b in 2:7
     @test check_complete_set(gg, b, 2)


### PR DESCRIPTION
The common test suite for all Hilbert implementations was in the main library, but it isn't needed by users. This moves that code into the test suite. It does this by making a separate module within the test suite, which solves a problem that SafeTestsets can't find code outside the test. It can, however, find modules outside the tests.