### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BijectiveHilbert"
 uuid = "91e7fc40-53cd-4118-bd19-d7fcd1de2a54"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Andrew Dolgert <adolgert@andrew.cmu.edu>"]
 
 [deps]


### PR DESCRIPTION
## Summary
- Bump version to 0.6.1 for release after #43 (accept Int arguments for encode/decode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)