### PR TITLE
Add CITATION.cff and CITATION.bib, bump version to 0.6.2

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,9 @@
+@software{dolgert2026bijectivehilbert,
+  author    = {Dolgert, Andrew},
+  title     = {{BijectiveHilbert.jl}},
+  version   = {0.6.2},
+  year      = {2026},
+  month     = {3},
+  url       = {https://github.com/adolgert/BijectiveHilbert.jl},
+  license   = {MIT}
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "BijectiveHilbert.jl"
+version: "0.6.2"
+date-released: "2026-03-19"
+url: "https://github.com/adolgert/BijectiveHilbert.jl"
+repository-code: "https://github.com/adolgert/BijectiveHilbert.jl"
+license: MIT
+authors:
+  - family-names: Dolgert
+    given-names: Andrew
+    orcid: "https://orcid.org/0000-0002-6477-7981"
+contributors:
+  - family-names: Geoga
+    given-names: Chris
+    orcid: "https://orcid.org/0000-0002-5060-4799"
+    affiliation: "University of Wisconsin-Madison"
+    city: Madison
+    country: US

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BijectiveHilbert"
 uuid = "91e7fc40-53cd-4118-bd19-d7fcd1de2a54"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Andrew Dolgert <adolgert@andrew.cmu.edu>"]
 
 [deps]


### PR DESCRIPTION
Add citation metadata for Zenodo integration. Includes author ORCID and contributor information.